### PR TITLE
Make hot-reloading work when running the docker container on its own.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,5 @@ COPY package.json .
 
 RUN npm install
 
-COPY . .
-
 EXPOSE 3000
 CMD [ "npm", "run", "start" ]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ mediawiki stack)
 
 ## Run dev
 
-docker build -t vue-server .
+`docker build -t vue-server .`
 
-docker run -p 3000:3000 vue-server
+`docker run -p 3000:3000 -v $(pwd):/usr/src/app vue-server`


### PR DESCRIPTION
Hot reloading only works when the local working directory is mounted as a volume on the docker container, so we probably always want to mount instead of using `COPY` (which does not track changes to the local file system).