### PR TITLE
Add note for node_modules problem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ mediawiki stack)
 
 `docker build -t vue-server .`
 
+If you run `npm install` from the host:
 `docker run -p 3000:3000 -v $(pwd):/usr/src/app vue-server`
+
+Otherwise (e.g. if you don't have npm installed):
+`docker run -p 3000:3000 -v $(pwd):/usr/src/app -v /usr/src/app/node_modules vue-server`
+This ensures that the `node_modules` directory does not get overridden by the mounted volume.
 
 Example page:
 http://localhost:3000/lemma-widget


### PR DESCRIPTION
We ran into trouble when deploying the service to http://wikibase-vue.wmflabs.org/ because the `node_modules` directory gets overridden and requires an `npm install` on the host. This patch adds the `node_modules` directory as a data volume so it stays accessible for the container.

Note: I believe this is not exactly a best practice, but should be ok for now. In the long run we might want to have a separate Dockerfile for deployment that does not care about things like hot-reloading and just copies the files instead of mounting the directories.